### PR TITLE
fix: CI/CD test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           repository: ScoopInstaller/Scoop
           path: scoop_core
       - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           modules-to-cache: BuildHelpers
           shell: powershell
@@ -48,7 +48,7 @@ jobs:
           repository: ScoopInstaller/Scoop
           path: scoop_core
       - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           modules-to-cache: BuildHelpers
           shell: pwsh


### PR DESCRIPTION
psmodulecache has a dependency, actions/cache. But psmodulecache v5.1 is using the recently deprecated version of actions/cache (v3.0.11). Due to the deprecation, every ci works are failed. Update it to the latest version which makes use of newer actions/cache

Source : https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
